### PR TITLE
Feature/issue#17:PageLayout 컴포넌트 구현

### DIFF
--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,0 +1,33 @@
+import  { ReactNode } from 'react';
+
+interface PageLayoutProps {
+  title: string; //페이지 상단 제목
+  children: ReactNode; // 페이지 내부에 렌더링할 하위 컴포넌트
+  padding?: string; // 레이아웃 여백 (Tailwind 클래스 문자열, 기본값: 'p-4')
+}
+
+// 공통 페이지 레이아웃 컴포넌트
+// - 제목은 상단 중앙 정렬
+// - 내용은 children으로 받아서 렌더링
+
+function PageLayout({
+  title,
+  children,
+  padding = 'p-4',
+}: PageLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* 페이지 콘텐츠 영역 */}
+      <main className={`${padding} flex-1`}>
+        {/* 페이지 타이틀 */}
+        <h1 className="py-8 text-center text-4xl font-bold text-white drop-shadow-lg">
+          {title}
+        </h1>
+        {/* 하위 컴포넌트 렌더링 */}
+        {children}
+      </main>
+    </div>
+  );
+}
+
+export default PageLayout;


### PR DESCRIPTION
## PR

### ✨ 작업 내용

- 공통 PageLayout 컴포넌트 구현
- title, children, padding props를 받아 페이지 레이아웃 구성

### 🔍 참고 사항
![image](https://github.com/user-attachments/assets/34a5b2fe-1794-4f11-a1bb-5827e1c177a0)
- 이런식으로 페이지 레이아웃이 적용됩니다


### ⚠️ 의논 필요

- 상단 중앙 정렬된 title 위치와 기본 padding('p-4')이 괜찮은지

### 🐞현재 버그

- 현재 없음

### #️⃣ 연관 이슈(Git Close)

closes #17

---

### 😊 리뷰 규칙을 지킵시다

코드 리뷰는 `Pn`룰에 따라 작성하기.  
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.

- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
